### PR TITLE
add pdb debugger to development workflow

### DIFF
--- a/logtivly/log_hours.py
+++ b/logtivly/log_hours.py
@@ -1,7 +1,7 @@
 
 from __future__ import print_function
 import json
-
+import rpdb; rpdb.set_trace()
 import datetime
 import sys
 from credentials import credentials

--- a/logtivly/requirements.txt
+++ b/logtivly/requirements.txt
@@ -1,2 +1,3 @@
 httplib2==0.10.3
+rpdb==0.1.6
 google_api_python_client==1.6.2


### PR DESCRIPTION
closes #6 

# rpdb: https://pypi.python.org/pypi/rpdb/
for debugging code in alfred runtime, now you can just add  `import rpdb; rpdb.set_trace()` before the line you want to start debugging, and trigger the script using alfred ie. `log test 10`

to enter the debugging session do: nc 127.0.0.1 4444 after triggering the script with alfred

dont forget to `pip install -r  requirements.txt` to install new packages (rpdb)